### PR TITLE
Fix warnings in Elixir 1.20

### DIFF
--- a/lib/phoenix_ddos/core/jail.ex
+++ b/lib/phoenix_ddos/core/jail.ex
@@ -2,7 +2,7 @@ defmodule PhoenixDDoS.Jail do
   @moduledoc """
     Ip got caught, go to jail ! Further request will be rejected and won't be included in rate limits
 
-    iex> PhoenixDDoS.Jail.send('1.2.3.4', Enum.at(Application.get_env( :phoenix_ddos,:_prots),0))
+    iex> PhoenixDDoS.Jail.send(~c"1.2.3.4", Enum.at(Application.get_env( :phoenix_ddos,:_prots),0))
     :ok
     iex> PhoenixDDoS.Jail.ips_in_jail()
     ["1.2.3.4"]

--- a/lib/phoenix_ddos/template/engine.eex
+++ b/lib/phoenix_ddos/template/engine.eex
@@ -109,7 +109,7 @@ defmodule PhoenixDDoS.Engine do
 <%= for {prot, cfg} <- Application.get_env(:phoenix_ddos,:_prots) do %>
   def get_prot_cfg("<%= cfg.id %>"), do: {<%= prot %>, <%= inspect(cfg) %>}
 <% end %>
-  def get_prot_cfg(_), do: {nil, nil}
+  def get_prot_cfg(_id), do: {nil, %{jail_time: {0, :seconds}}}
 
 <%= for ip <- Application.get_env(:phoenix_ddos, :blocklist_ips, []) do %>
   def blocklist_ips?(<%= inspect(ip) %>), do: true


### PR DESCRIPTION
Compiling and running PhoenixDDOS in Elixir 1.20 gives some warnings. This attempts to fix them.

- The `'` -> `~c"` is fairly straightforward
- Returning `{nil, nil}` from `get_prot_cfg/1` was spotted to have failed later in `Jail.send/2`. Update the returned value to match the format expected in `Jail.send/2`.
